### PR TITLE
add basic test setup

### DIFF
--- a/include/parser.h
+++ b/include/parser.h
@@ -1,0 +1,6 @@
+#pragma once
+
+#include <stdio.h>
+#include <dynamicString.h>
+
+DynamicString parseMarkdown(FILE * file);

--- a/lib/dynamicString.c
+++ b/lib/dynamicString.c
@@ -1,8 +1,11 @@
 #include <stdlib.h>
+#include <stdio.h>
 #include <string.h>
 #include <dynamicString.h>
 
 static size_t MIN_CAPACITY = 64;
+
+static int ensureCapacity(DynamicString * dynStr, size_t neededCapacity);
 
 DynamicString createDynStr(const char * initialStr, size_t len) {
     DynamicString dynStr;
@@ -40,7 +43,7 @@ int appendDynStr(DynamicString * dynStr, const char * newStr, size_t len) {
     return 1;
 }
 
-int appendDynCh(DynamicString * dynStr, const char newCh) {
+int appendDynChar(DynamicString * dynStr, const char newCh) {
     int newCapacity = dynStr->len + 2;
     if (!ensureCapacity(dynStr, newCapacity)) {
         return 0;
@@ -52,6 +55,15 @@ int appendDynCh(DynamicString * dynStr, const char newCh) {
 
     return 1;
 }
+
+void freeDynStr(DynamicString * dynStr) {
+    free(dynStr->str);
+    dynStr->str = NULL;
+    dynStr->capacity = 0;
+    dynStr->len = 0;
+}
+
+// internal
 
 static int ensureCapacity(DynamicString * dynStr, size_t neededCapacity) {
     if (dynStr->capacity > neededCapacity) {
@@ -74,11 +86,4 @@ static int ensureCapacity(DynamicString * dynStr, size_t neededCapacity) {
     dynStr->capacity = newCapacity;
 
     return 1;
-}
-
-void freeDynStr(DynamicString * dynStr) {
-    free(dynStr->str);
-    dynStr->str = NULL;
-    dynStr->capacity = 0;
-    dynStr->len = 0;
 }

--- a/tests/test.c
+++ b/tests/test.c
@@ -1,0 +1,69 @@
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "parser.h"
+
+static char * FILE_NAME = "test.md";
+
+static FILE * setupFile(char * text) {
+    FILE * fd = fopen(FILE_NAME, "w");
+    if (fd == NULL) {
+        exit(1);
+    }
+
+    fputs(text, fd);
+
+    fclose(fd);
+
+    fd = fopen(FILE_NAME, "r");
+    return fd;
+}
+
+static void teardownFile(FILE * fd, DynamicString * dynStr) {
+    fclose(fd);
+
+    int result = remove(FILE_NAME);
+
+    if (result != 0) {
+        exit(1);
+    }
+
+    freeDynStr(dynStr);
+}
+
+static void test_correctParagraphWrapperTag(void **state) {
+    (void) state; /* unused parameter */
+
+    FILE * fd = setupFile("Hello, world!");
+
+    DynamicString dynStr = parseMarkdown(fd);
+
+    assert_string_equal(dynStr.str, "<p>Hello, world!</p>");
+
+    teardownFile(fd, &dynStr);
+}
+
+static void test_correctHeaderWrapperTag(void **state) {
+    (void) state; /* unused parameter */
+
+    FILE * fd = setupFile("### Hello, world!");
+
+    DynamicString dynStr = parseMarkdown(fd);
+
+    assert_string_equal(dynStr.str, "<h3>Hello, world!</h3>");
+
+    teardownFile(fd, &dynStr);
+}
+
+int main(void) {
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test(test_correctParagraphWrapperTag),
+        cmocka_unit_test(test_correctHeaderWrapperTag),
+    };
+
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}

--- a/xmake.lua
+++ b/xmake.lua
@@ -1,9 +1,21 @@
 add_rules("mode.debug", "mode.release")
+add_requires("cmocka")
+
+target("parserlib")
+    set_kind("static")
+    add_files("lib/*.c")
+    add_includedirs("include", { public = true})
 
 target("md-parser")
     set_kind("binary")
     add_files("src/*.c")
-    add_includedirs("include")
+    add_deps("parserlib")
+
+target("tests")
+    set_kind("binary")
+    add_files("tests/*.c")
+    add_deps("parserlib")
+    add_packages("cmocka")
 
 --
 -- If you want to known more usage about xmake, please see https://xmake.io


### PR DESCRIPTION
## Description

Add basic test setup (not on CI, though) and add 2 basic tests for a header and regular p wrapper tags.

It uses `cmocka` library, which is installed by xmake automatically when running.