### PR TITLE
add basic bold support

### DIFF
--- a/tests/test.c
+++ b/tests/test.c
@@ -95,6 +95,18 @@ static void test_correctInlineCodeSupport(void **state) {
     teardownFile(fd, &dynStr);
 }
 
+static void test_correctBoldSupport(void **state) {
+    (void) state; /* unused parameter */
+
+    FILE * fd = setupFile("some text **with bold text** and _more_");
+
+    DynamicString dynStr = parseMarkdown(fd);
+
+    assert_string_equal(dynStr.str, "<p>some text <strong>with bold text</strong> and <i>more</i></p>");
+
+    teardownFile(fd, &dynStr);
+}
+
 int main(void) {
     const struct CMUnitTest tests[] = {
         cmocka_unit_test(test_correctParagraphWrapperTag),
@@ -102,6 +114,7 @@ int main(void) {
         cmocka_unit_test(test_correctMultilineSupport),
         cmocka_unit_test(test_correctItalicSupport),
         cmocka_unit_test(test_correctInlineCodeSupport),
+        cmocka_unit_test(test_correctBoldSupport),
     };
 
     return cmocka_run_group_tests(tests, NULL, NULL);


### PR DESCRIPTION
## Description

This PR adds a very basic bold support. It is super basic in a sense that it does not account for any nested code, and right now it does not accept `this *italics code*` as italics, so the implementation is very simple.

## Reference

Should close #7 