### PR TITLE
Add multiline paragraph support

### DIFF
--- a/include/parserState.h
+++ b/include/parserState.h
@@ -13,6 +13,7 @@ typedef struct ParserState {
     int canParseHeader;
     int headerLevel;
     int openedTag;
+    int firstLine;
     char previousCharacter;
     Tag tag;
     DynamicString str;

--- a/lib/parserState.c
+++ b/lib/parserState.c
@@ -5,6 +5,7 @@ void resetParserLineState(ParserState *parserState) {
     parserState->canParseHeader = 1;
     parserState->headerLevel = 0;
     parserState->openedTag = 0;
+    parserState->firstLine = 1;
 }
 
 void resetParserStr(ParserState *parserState) {


### PR DESCRIPTION
## Description

Add multiline support for paragraphs. Basically, just adding a new line will only add `<br />` tag instead of closing the `</p>` tag.

## References

Closes https://github.com/Bloomca/c-md-parser/issues/14